### PR TITLE
Enhance the init script template a bit

### DIFF
--- a/templates/mule.init.erb
+++ b/templates/mule.init.erb
@@ -42,7 +42,7 @@ stop() {
         rm -f ${PID_FILE}
     else
         # The mule procs for mule cle user
-        PIDS=`ps -u ${MULE_USER} --no-headers -o pid,cmd | grep "${MULE_HOME}" | awk '{ print $1 }'`
+        PIDS=`ps -u ${MULE_USER} --no-headers -o pid,cmd | grep "${MULE_HOME}" | grep -v grep | awk '{ print $1 }'`
         for PID in ${PIDS}; do
             for  i in 1 2 3; do
                 if [[ -d /proc/${PID} ]]; then
@@ -66,7 +66,7 @@ status(){
 	    PID=`cat ${PID_FILE}`
     else
         # The mule procs for mule cle user
-        PID=`ps -u ${MULE_USER} --no-headers -o pid,cmd | grep "${MULE_HOME}" | awk '{ print $1 }'`
+        PID=`ps -u ${MULE_USER} --no-headers -o pid,cmd | grep "${MULE_HOME}" | grep -v grep | awk '{ print $1 }'`
     fi
 
     EXIT=0


### PR DESCRIPTION
When there is no PID file, and
mule is running as root user, then the init script greps the
ps output, and falsely might catch the grep in ps output instead
of a mule process.
Therefore filter out potential grep from ps.