### PR TITLE
Set permissions on some directories to the mule user/group when

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,7 +44,7 @@ class mule(
 
   archive { $dist:
     ensure           => present,
-    url              => "${archive}",
+    url              => $archive,
     target           => $mule_install_dir,
     checksum         => false,
     timeout          => 0,
@@ -57,11 +57,17 @@ class mule(
     require => Archive[$dist]
   }
 
-  file { "${mule_install_dir}/${dist}":
+  $user_owned_dirs = ["${basedir}/conf", "${basedir}/bin",
+                        "${basedir}/domains",
+                        "${basedir}/logs",
+                        "${basedir}/apps",
+                        "${mule_install_dir}/${dist}", ]
+
+  file { $user_owned_dirs:
     ensure  => directory,
     owner   => $user,
     group   => $group,
-    require => Archive[$dist]
+    require => Archive[$dist],
   }
 
   file { '/etc/profile.d/mule.sh':
@@ -72,8 +78,8 @@ class mule(
 
   file { '/etc/init.d/mule':
     ensure  => present,
-    owner   => $user,
-    group   => $group,
+    owner   => 'root',
+    group   => '0',
     mode    => '0755',
     content => template('mule/mule.init.erb'),
     require => File[$basedir]


### PR DESCRIPTION
not running as root in order to let the mule deploy and start up
successfully.

After having mule running as root, I tried it again, with a created
mule user/group. That failed miserably deploying the mule zip 
files as well as starting up. 
Reason for that was that the archive was extracted as root,
and therefore the directories were owned as root. Then the
mule user were not able to write into a couple of such dirs.
Esp. creating log files, and some other files.
With the list below of directories, changing ownership to 
mule:mule, I was then able to start up mule as the underprivileged
user.

Contrary to that, there is no need for the init script to be owned
by the mule system user, therefore changed it to root:0.
I used group 0, since I know on *BSD, and maybe other OS,
the group name of the root user is wheel instead of root.

Did my test with mule 3.7.0 on SLES 11 SP3


While there, make puppet-lint happy so that travis-ci is green,
even there are no spec tests ;)

let me know if there is something to change/enhance and I'll happily do.

cheers,
Sebastian